### PR TITLE
hotfix of argument types

### DIFF
--- a/packages/hecs/src/index.ts
+++ b/packages/hecs/src/index.ts
@@ -270,20 +270,20 @@ export class World {
     a: TQueryParameter<A>,
     b: TQueryParameter<B>,
     c: TQueryParameter<C>,
-    d: TQueryParameter<C>
+    d: TQueryParameter<D>
   ): IQuery<[A, B, C, D]>;
   public createQuery<A, B, C, D, E>(
     a: TQueryParameter<A>,
     b: TQueryParameter<B>,
     c: TQueryParameter<C>,
-    d: TQueryParameter<C>,
+    d: TQueryParameter<D>,
     e: TQueryParameter<E>
   ): IQuery<[A, B, C, D, E]>;
   public createQuery<A, B, C, D, E, F>(
     a: TQueryParameter<A>,
     b: TQueryParameter<B>,
     c: TQueryParameter<C>,
-    d: TQueryParameter<C>,
+    d: TQueryParameter<D>,
     e: TQueryParameter<E>,
     f: TQueryParameter<F>
   ): IQuery<[A, B, C, D, E, F]>;


### PR DESCRIPTION
Small typo ruins usage of more than 3 components in query